### PR TITLE
feat(test): add e2e test in kcl for claim and xr

### DIFF
--- a/functions/compose-bucket-kcl/main.k
+++ b/functions/compose-bucket-kcl/main.k
@@ -1,7 +1,9 @@
 import models.io.upbound.aws.s3.v1beta1 as s3v1beta1
 import models.com.example.platform.v1alpha1.xstoragebucket as xstoragebucketv1alpha1
 
-oxr = xstoragebucketv1alpha1.XStorageBucket{**option("params").oxr}
+oxr = option("params").oxr
+# https://github.com/upbound/up/pull/432
+# oxr = xstoragebucketv1alpha1.XStorageBucket{**option("params").oxr}
 
 bucketName = "{}-bucket".format(oxr.metadata.name)
 

--- a/tests/e2etest-storagebucket/kcl.mod
+++ b/tests/e2etest-storagebucket/kcl.mod
@@ -1,0 +1,6 @@
+[package]
+name = "e2etest-storagebucket"
+version = "0.0.1"
+
+[dependencies]
+models = { path = "./model" }

--- a/tests/e2etest-storagebucket/kcl.mod.lock
+++ b/tests/e2etest-storagebucket/kcl.mod.lock
@@ -1,0 +1,12 @@
+[dependencies]
+  [dependencies.model]
+    name = "model"
+    full_name = "models_0.0.1"
+    version = "0.0.1"
+    reg = "ghcr.io"
+    repo = "kcl-lang/model"
+    oci_tag = "0.0.1"
+  [dependencies.models]
+    name = "models"
+    full_name = "models_0.0.1"
+    version = "0.0.1"

--- a/tests/e2etest-storagebucket/main.k
+++ b/tests/e2etest-storagebucket/main.k
@@ -1,0 +1,43 @@
+import models.com.example.platform.v1alpha1 as platformv1alpha1
+import models.io.upbound.aws.v1beta1 as awsv1beta1
+import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+
+_items = [
+    metav1alpha1.E2ETest{
+        metadata.name = "storagebucket"
+        spec = {
+            crossplane.autoUpgrade.channel = "Rapid"
+            defaultConditions = [
+                "Ready"
+            ]
+            manifests = [
+                platformv1alpha1.StorageBucket{
+                    metadata = {
+                        name = "uptest-bucket-claim"
+                        namespace = "default"
+                    }
+                    spec.parameters = {
+                        acl = "private"
+                        region = "eu-central-1"
+                        versioning: True
+                    }
+                }
+            ]
+            extraResources= [
+                awsv1beta1.ProviderConfig{
+                    metadata.name = "default"
+                    spec.credentials = {
+                        source = "Upbound"
+                        upbound.webIdentity = {
+                            roleARN = "arn:aws:iam::609897127049:role/example-project-aws-uptest"
+                        }
+                    }
+                }
+            ]
+            skipDelete = False
+            timeoutSeconds = 4500
+        }
+    }
+]
+items = _items
+

--- a/tests/e2etest-storagebucket/model
+++ b/tests/e2etest-storagebucket/model
@@ -1,0 +1,1 @@
+../../.up/kcl/models

--- a/tests/e2etest-xstoragebucket/kcl.mod
+++ b/tests/e2etest-xstoragebucket/kcl.mod
@@ -1,0 +1,6 @@
+[package]
+name = "e2etest-xstoragebucket"
+version = "0.0.1"
+
+[dependencies]
+models = { path = "./model" }

--- a/tests/e2etest-xstoragebucket/kcl.mod.lock
+++ b/tests/e2etest-xstoragebucket/kcl.mod.lock
@@ -1,0 +1,12 @@
+[dependencies]
+  [dependencies.model]
+    name = "model"
+    full_name = "models_0.0.1"
+    version = "0.0.1"
+    reg = "ghcr.io"
+    repo = "kcl-lang/model"
+    oci_tag = "0.0.1"
+  [dependencies.models]
+    name = "models"
+    full_name = "models_0.0.1"
+    version = "0.0.1"

--- a/tests/e2etest-xstoragebucket/main.k
+++ b/tests/e2etest-xstoragebucket/main.k
@@ -1,0 +1,39 @@
+import models.com.example.platform.v1alpha1 as platformv1alpha1
+import models.io.upbound.aws.v1beta1 as awsv1beta1
+import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+
+_items = [
+    metav1alpha1.E2ETest{
+        metadata.name = "xstoragebucket"
+        spec = {
+            crossplane.autoUpgrade.channel = "Rapid"
+            defaultConditions = [
+                "Ready"
+            ]
+            manifests = [
+                platformv1alpha1.XStorageBucket{
+                    metadata.name = "uptest-bucket-xr"
+                    spec.parameters = {
+                        acl = "private"
+                        region = "eu-central-1"
+                        versioning: True
+                    }
+                }
+            ]
+            extraResources = [
+                awsv1beta1.ProviderConfig{
+                    metadata.name = "default"
+                    spec.credentials = {
+                        source = "Upbound"
+                        upbound.webIdentity = {
+                            roleARN = "arn:aws:iam::609897127049:role/example-project-aws-uptest"
+                        }
+                    }
+                }
+            ]
+            skipDelete = False
+            timeoutSeconds = 4500
+        }
+    }
+]
+items = _items

--- a/tests/e2etest-xstoragebucket/model
+++ b/tests/e2etest-xstoragebucket/model
@@ -1,0 +1,1 @@
+../../.up/kcl/models


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- add e2e test in kcl for claim and xr

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
up test run tests/ --e2e --chainsaw=/Users/haarchri/Documents/chainsaw/chainsaw
  ✓   Parsing project metadata                                                                                         
  ✓   Parsing tests                                                                                                    
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Building functions
  ✓   Building configuration package
  ✓   Ensuring repository exists
  ✓   Pushing function package xpkg.upbound.io/upbound/example-project-aws_compose-bucket-python
  ✓   Pushing function package xpkg.upbound.io/upbound/example-project-aws_compose-bucket-kcl
  ✓   Pushing configuration image xpkg.upbound.io/upbound/example-project-aws:v0.0.0-1738179847
  ✓   Creating development control plane
  ✓   Installing package on development control plane                                                                  
  ✓   Waiting for package to be ready                                                                                  
  ✓   Applying Extra Resources                                                                                         
2025/01/29 20:45:18 Skipping update step because the root resource does not exist
2025/01/29 20:45:18 Skipping update step because the skip-delete option is set to true
2025/01/29 20:45:18 Skipping import step because the skip-import option is set to true
2025/01/29 20:45:18 Written test files: /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231
2025/01/29 20:45:18 Running chainsaw tests at /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231
2025/01/29 20:45:18 Version: (devel)
2025/01/29 20:45:18 Loading default configuration...
2025/01/29 20:45:18 - Using test file: 00-apply.yaml
2025/01/29 20:45:18 - TestDirs [/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231/case]
2025/01/29 20:45:18 - SkipDelete true
2025/01/29 20:45:18 - FailFast false
2025/01/29 20:45:18 - Namespace ''
2025/01/29 20:45:18 - FullName false
2025/01/29 20:45:18 - IncludeTestRegex ''
2025/01/29 20:45:18 - ExcludeTestRegex ''
2025/01/29 20:45:18 - ApplyTimeout 5s
2025/01/29 20:45:18 - AssertTimeout 30s
2025/01/29 20:45:18 - CleanupTimeout 30s
2025/01/29 20:45:18 - DeleteTimeout 15s
2025/01/29 20:45:18 - ErrorTimeout 30s
2025/01/29 20:45:18 - ExecTimeout 5s
2025/01/29 20:45:18 - DeletionPropagationPolicy Background
2025/01/29 20:45:18 - Parallel 1
2025/01/29 20:45:18 - Template true
2025/01/29 20:45:18 - NoCluster false
2025/01/29 20:45:18 - PauseOnFailure false
2025/01/29 20:45:18 Loading tests...
2025/01/29 20:45:18 - apply (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231/case)
2025/01/29 20:45:18 Loading values...
2025/01/29 20:45:18 Running tests...
2025/01/29 20:45:18 === RUN   chainsaw
2025/01/29 20:45:18 === PAUSE chainsaw
2025/01/29 20:45:18 === CONT  chainsaw
2025/01/29 20:45:18 === RUN   chainsaw/apply
2025/01/29 20:45:18 === PAUSE chainsaw/apply
2025/01/29 20:45:18 === CONT  chainsaw/apply
2025/01/29 20:45:20     | 20:45:20 | apply | @chainsaw                | CREATE    | OK    | v1/Namespace @ chainsaw-immune-goshawk
2025/01/29 20:45:20     | 20:45:20 | apply | Apply Resources          | TRY       | BEGIN |
2025/01/29 20:45:20     | 20:45:20 | apply | Apply Resources          | APPLY     | RUN   | platform.example.com/v1alpha1/StorageBucket @ default/uptest-bucket-claim
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | CREATE    | OK    | platform.example.com/v1alpha1/StorageBucket @ default/uptest-bucket-claim
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | APPLY     | DONE  | platform.example.com/v1alpha1/StorageBucket @ default/uptest-bucket-claim
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | CMD       | RUN   |
2025/01/29 20:45:21         === COMMAND
2025/01/29 20:45:21         /bin/sh -c echo "Runnning annotation script"
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | SCRIPT    | LOG   |
2025/01/29 20:45:21         === STDOUT
2025/01/29 20:45:21         Runnning annotation script
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | SCRIPT    | DONE  |
2025/01/29 20:45:21     | 20:45:21 | apply | Apply Resources          | TRY       | END   |
2025/01/29 20:45:21     | 20:45:21 | apply | Assert Status Conditions | TRY       | BEGIN |
2025/01/29 20:45:21     | 20:45:21 | apply | Assert Status Conditions | ASSERT    | RUN   | platform.example.com/v1alpha1/StorageBucket @ default/uptest-bucket-claim
2025/01/29 20:46:27     | 20:46:27 | apply | Assert Status Conditions | ASSERT    | DONE  | platform.example.com/v1alpha1/StorageBucket @ default/uptest-bucket-claim
2025/01/29 20:46:27     | 20:46:27 | apply | Assert Status Conditions | TRY       | END   |
2025/01/29 20:46:27     | 20:46:27 | apply | @chainsaw                | CLEANUP   | SKIP  |
2025/01/29 20:46:27 === NAME  chainsaw
2025/01/29 20:46:27     | 20:46:27 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
2025/01/29 20:46:27 --- PASS: chainsaw (0.00s)
2025/01/29 20:46:27     --- PASS: chainsaw/apply (68.66s)
2025/01/29 20:46:27 PASS
2025/01/29 20:46:27 Tests Summary...
2025/01/29 20:46:27 - Passed  tests 1
2025/01/29 20:46:27 - Failed  tests 0
2025/01/29 20:46:27 - Skipped tests 0
2025/01/29 20:46:27 Done.
2025/01/29 20:46:27 Skipping test 01-update.yaml
2025/01/29 20:46:27 Skipping test 02-import.yaml
2025/01/29 20:46:27 Version: (devel)
2025/01/29 20:46:27 Loading default configuration...
2025/01/29 20:46:27 - Using test file: 03-delete.yaml
2025/01/29 20:46:27 - TestDirs [/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231/case]
2025/01/29 20:46:27 - SkipDelete true
2025/01/29 20:46:27 - FailFast false
2025/01/29 20:46:27 - Namespace ''
2025/01/29 20:46:27 - FullName false
2025/01/29 20:46:27 - IncludeTestRegex ''
2025/01/29 20:46:27 - ExcludeTestRegex ''
2025/01/29 20:46:27 - ApplyTimeout 5s
2025/01/29 20:46:27 - AssertTimeout 30s
2025/01/29 20:46:27 - CleanupTimeout 30s
2025/01/29 20:46:27 - DeleteTimeout 15s
2025/01/29 20:46:27 - ErrorTimeout 30s
2025/01/29 20:46:27 - ExecTimeout 5s
2025/01/29 20:46:27 - DeletionPropagationPolicy Background
2025/01/29 20:46:27 - Parallel 1
2025/01/29 20:46:27 - Template true
2025/01/29 20:46:27 - NoCluster false
2025/01/29 20:46:27 - PauseOnFailure false
2025/01/29 20:46:27 Loading tests...
2025/01/29 20:46:27 - delete (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/storagebucket1584615231/case)
2025/01/29 20:46:27 Loading values...
2025/01/29 20:46:27 Running tests...
2025/01/29 20:46:27 === RUN   chainsaw
2025/01/29 20:46:27 === PAUSE chainsaw
2025/01/29 20:46:27 === CONT  chainsaw
2025/01/29 20:46:27 === RUN   chainsaw/delete
2025/01/29 20:46:27 === PAUSE chainsaw/delete
2025/01/29 20:46:27 === CONT  chainsaw/delete
2025/01/29 20:46:28     | 20:46:28 | delete | @chainsaw        | CREATE    | OK    | v1/Namespace @ chainsaw-true-robin
2025/01/29 20:46:28     | 20:46:28 | delete | Delete Resources | TRY       | BEGIN |
2025/01/29 20:46:28     | 20:46:28 | delete | Delete Resources | CMD       | RUN   |
2025/01/29 20:46:28         === COMMAND
2025/01/29 20:46:28         /bin/sh -c ${KUBECTL} delete storagebucket.platform.example.com/uptest-bucket-claim --wait=false --namespace default --ignore-not-found
2025/01/29 20:46:29     | 20:46:29 | delete | Delete Resources | SCRIPT    | LOG   |
2025/01/29 20:46:29         === STDOUT
2025/01/29 20:46:29         storagebucket.platform.example.com "uptest-bucket-claim" deleted
2025/01/29 20:46:29     | 20:46:29 | delete | Delete Resources | SCRIPT    | DONE  |
2025/01/29 20:46:29     | 20:46:29 | delete | Delete Resources | TRY       | END   |
2025/01/29 20:46:29     | 20:46:29 | delete | Assert Deletion  | TRY       | BEGIN |
2025/01/29 20:46:29     | 20:46:29 | delete | Assert Deletion  | CMD       | RUN   |
2025/01/29 20:46:29         === COMMAND
2025/01/29 20:46:29         /usr/local/bin/kubectl wait storagebuckets.v1alpha1.platform.example.com --for=delete uptest-bucket-claim -n default --timeout 1h15m0s
2025/01/29 20:46:30     | 20:46:30 | delete | Assert Deletion  | CMD       | DONE  |
2025/01/29 20:46:30     | 20:46:30 | delete | Assert Deletion  | TRY       | END   |
2025/01/29 20:46:30     | 20:46:30 | delete | @chainsaw        | CLEANUP   | SKIP  |
2025/01/29 20:46:30 === NAME  chainsaw
  ✓   Creating development control plane
  ✓   Installing package on development control plane                                                                  
  ✓   Waiting for package to be ready                                                                                  
  ✓   Applying Extra Resources                                                                                         
2025/01/29 20:47:25 Skipping update step because the root resource does not exist
2025/01/29 20:47:25 Skipping update step because the skip-delete option is set to true
2025/01/29 20:47:25 Skipping import step because the skip-import option is set to true
2025/01/29 20:47:25 Written test files: /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381
2025/01/29 20:47:25 Running chainsaw tests at /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381
2025/01/29 20:47:26 Version: (devel)
2025/01/29 20:47:26 Loading default configuration...
2025/01/29 20:47:26 - Using test file: 00-apply.yaml
2025/01/29 20:47:26 - TestDirs [/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381/case]
2025/01/29 20:47:26 - SkipDelete true
2025/01/29 20:47:26 - FailFast false
2025/01/29 20:47:26 - Namespace ''
2025/01/29 20:47:26 - FullName false
2025/01/29 20:47:26 - IncludeTestRegex ''
2025/01/29 20:47:26 - ExcludeTestRegex ''
2025/01/29 20:47:26 - ApplyTimeout 5s
2025/01/29 20:47:26 - AssertTimeout 30s
2025/01/29 20:47:26 - CleanupTimeout 30s
2025/01/29 20:47:26 - DeleteTimeout 15s
2025/01/29 20:47:26 - ErrorTimeout 30s
2025/01/29 20:47:26 - ExecTimeout 5s
2025/01/29 20:47:26 - DeletionPropagationPolicy Background
2025/01/29 20:47:26 - Parallel 1
2025/01/29 20:47:26 - Template true
2025/01/29 20:47:26 - NoCluster false
2025/01/29 20:47:26 - PauseOnFailure false
2025/01/29 20:47:26 Loading tests...
2025/01/29 20:47:26 - apply (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381/case)
2025/01/29 20:47:26 Loading values...
2025/01/29 20:47:26 Running tests...
2025/01/29 20:47:26 === RUN   chainsaw
2025/01/29 20:47:26 === PAUSE chainsaw
2025/01/29 20:47:26 === CONT  chainsaw
2025/01/29 20:47:26 === RUN   chainsaw/apply
2025/01/29 20:47:26 === PAUSE chainsaw/apply
2025/01/29 20:47:26 === CONT  chainsaw/apply
2025/01/29 20:47:27     | 20:47:27 | apply | @chainsaw                | CREATE    | OK    | v1/Namespace @ chainsaw-close-lion
2025/01/29 20:47:27     | 20:47:27 | apply | Apply Resources          | TRY       | BEGIN |
2025/01/29 20:47:27     | 20:47:27 | apply | Apply Resources          | APPLY     | RUN   | platform.example.com/v1alpha1/XStorageBucket @ uptest-bucket-xr
2025/01/29 20:47:27     | 20:47:27 | apply | Apply Resources          | CREATE    | OK    | platform.example.com/v1alpha1/XStorageBucket @ uptest-bucket-xr
2025/01/29 20:47:27     | 20:47:27 | apply | Apply Resources          | APPLY     | DONE  | platform.example.com/v1alpha1/XStorageBucket @ uptest-bucket-xr
2025/01/29 20:47:27     | 20:47:27 | apply | Apply Resources          | CMD       | RUN   |
2025/01/29 20:47:27         === COMMAND
2025/01/29 20:47:27         /bin/sh -c echo "Runnning annotation script"
2025/01/29 20:47:27         ${KUBECTL} annotate xstoragebucket.platform.example.com/uptest-bucket-xr upjet.upbound.io/test=true --overwrite
2025/01/29 20:47:29     | 20:47:29 | apply | Apply Resources          | SCRIPT    | LOG   |
2025/01/29 20:47:29         === STDOUT
2025/01/29 20:47:29         Runnning annotation script
2025/01/29 20:47:29         xstoragebucket.platform.example.com/uptest-bucket-xr annotated
2025/01/29 20:47:29     | 20:47:29 | apply | Apply Resources          | SCRIPT    | DONE  |
2025/01/29 20:47:29     | 20:47:29 | apply | Apply Resources          | TRY       | END   |
2025/01/29 20:47:29     | 20:47:29 | apply | Assert Status Conditions | TRY       | BEGIN |
2025/01/29 20:47:29     | 20:47:29 | apply | Assert Status Conditions | ASSERT    | RUN   | platform.example.com/v1alpha1/XStorageBucket @ uptest-bucket-xr
2025/01/29 20:49:30     | 20:49:30 | apply | Assert Status Conditions | ASSERT    | DONE  | platform.example.com/v1alpha1/XStorageBucket @ uptest-bucket-xr
2025/01/29 20:49:30     | 20:49:30 | apply | Assert Status Conditions | TRY       | END   |
2025/01/29 20:49:30     | 20:49:30 | apply | @chainsaw                | CLEANUP   | SKIP  |
2025/01/29 20:49:30 === NAME  chainsaw
2025/01/29 20:49:30     | 20:49:30 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
2025/01/29 20:49:30 --- PASS: chainsaw (0.00s)
2025/01/29 20:49:30     --- PASS: chainsaw/apply (124.38s)
2025/01/29 20:49:30 PASS
2025/01/29 20:49:30 Tests Summary...
2025/01/29 20:49:30 - Passed  tests 1
2025/01/29 20:49:30 - Failed  tests 0
2025/01/29 20:49:30 - Skipped tests 0
2025/01/29 20:49:30 Done.
2025/01/29 20:49:30 Skipping test 01-update.yaml
2025/01/29 20:49:30 Skipping test 02-import.yaml
2025/01/29 20:49:30 Version: (devel)
2025/01/29 20:49:30 Loading default configuration...
2025/01/29 20:49:30 - Using test file: 03-delete.yaml
2025/01/29 20:49:30 - TestDirs [/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381/case]
2025/01/29 20:49:30 - SkipDelete true
2025/01/29 20:49:30 - FailFast false
2025/01/29 20:49:30 - Namespace ''
2025/01/29 20:49:30 - FullName false
2025/01/29 20:49:30 - IncludeTestRegex ''
2025/01/29 20:49:30 - ExcludeTestRegex ''
2025/01/29 20:49:30 - ApplyTimeout 5s
2025/01/29 20:49:30 - AssertTimeout 30s
2025/01/29 20:49:30 - CleanupTimeout 30s
2025/01/29 20:49:30 - DeleteTimeout 15s
2025/01/29 20:49:30 - ErrorTimeout 30s
2025/01/29 20:49:30 - ExecTimeout 5s
2025/01/29 20:49:30 - DeletionPropagationPolicy Background
2025/01/29 20:49:30 - Parallel 1
2025/01/29 20:49:30 - Template true
2025/01/29 20:49:30 - NoCluster false
2025/01/29 20:49:30 - PauseOnFailure false
2025/01/29 20:49:30 Loading tests...
2025/01/29 20:49:30 - delete (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xstoragebucket1656457381/case)
2025/01/29 20:49:30 Loading values...
2025/01/29 20:49:30 Running tests...
2025/01/29 20:49:30 === RUN   chainsaw
2025/01/29 20:49:30 === PAUSE chainsaw
2025/01/29 20:49:30 === CONT  chainsaw
2025/01/29 20:49:30 === RUN   chainsaw/delete
2025/01/29 20:49:30 === PAUSE chainsaw/delete
2025/01/29 20:49:30 === CONT  chainsaw/delete
2025/01/29 20:49:31     | 20:49:31 | delete | @chainsaw        | CREATE    | OK    | v1/Namespace @ chainsaw-up-slug
2025/01/29 20:49:31     | 20:49:31 | delete | Delete Resources | TRY       | BEGIN |
2025/01/29 20:49:31     | 20:49:31 | delete | Delete Resources | CMD       | RUN   |
2025/01/29 20:49:31         === COMMAND
2025/01/29 20:49:31         /bin/sh -c ${KUBECTL} delete xstoragebucket.platform.example.com/uptest-bucket-xr --wait=false --ignore-not-found
2025/01/29 20:49:33     | 20:49:33 | delete | Delete Resources | SCRIPT    | LOG   |
2025/01/29 20:49:33         === STDOUT
2025/01/29 20:49:33         xstoragebucket.platform.example.com "uptest-bucket-xr" deleted
2025/01/29 20:49:33     | 20:49:33 | delete | Delete Resources | SCRIPT    | DONE  |
2025/01/29 20:49:33     | 20:49:33 | delete | Delete Resources | TRY       | END   |
2025/01/29 20:49:33     | 20:49:33 | delete | Assert Deletion  | TRY       | BEGIN |
2025/01/29 20:49:33     | 20:49:33 | delete | Assert Deletion  | CMD       | RUN   |
2025/01/29 20:49:33         === COMMAND
2025/01/29 20:49:33         /usr/local/bin/kubectl wait xstoragebuckets.v1alpha1.platform.example.com --for=delete uptest-bucket-xr --timeout 1h15m0s
2025/01/29 20:49:34     | 20:49:34 | delete | Assert Deletion  | CMD       | DONE  |
2025/01/29 20:49:34     | 20:49:34 | delete | Assert Deletion  | TRY       | END   |
2025/01/29 20:49:34     | 20:49:34 | delete | @chainsaw        | CLEANUP   | SKIP  |
2025/01/29 20:49:34 === NAME  chainsaw
2025/01/29 20:49:34     | 20:49:34 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
2025/01/29 20:49:34 --- PASS: chainsaw (0.00s)
2025/01/29 20:49:34     --- PASS: chainsaw/delete (3.50s)
2025/01/29 20:49:34 PASS
2025/01/29 20:49:34 Tests Summary...
2025/01/29 20:49:34 - Passed  tests 1
2025/01/29 20:49:34 - Failed  tests 0
2025/01/29 20:49:34 - Skipped tests 0
2025/01/29 20:49:34 Done.
 SUCCESS  
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 2
 SUCCESS  Passed tests:         2
 SUCCESS  Failed tests:         0
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
